### PR TITLE
fix Shaders.lua for mobile glsl shaders

### DIFF
--- a/Shaders.lua
+++ b/Shaders.lua
@@ -37,7 +37,7 @@ Shadows.BloomShader = love.graphics.newShader [[
 			}
 		}
 		
-		return (sum / ( Samples * Samples ) + source) * color;
+		return (sum / (float( Samples * Samples )) + source) * color;
 	}
 ]]; Shadows.BloomShader:send("Quality", 4)
   ; Shadows.BloomShader:sendInt("Samples", 1)


### PR DESCRIPTION
This extremely minor change makes the shaders work fully on mobile glsl again without any compilation problems by readding the explicit type cast glsl cannot infer