### PR TITLE
Support Love 0.11

### DIFF
--- a/Body.lua
+++ b/Body.lua
@@ -129,7 +129,7 @@ end
 
 function Body:InitFromPhysics(Body)
 	
-	for Index, Fixture in pairs(Body:getFixtureList()) do
+	for Index, Fixture in pairs(Body:getFixtures()) do
 		
 		local Shape = Fixture:getShape()
 		local Type = Shape:getType()

--- a/Light.lua
+++ b/Light.lua
@@ -260,7 +260,7 @@ function Light:Update()
 		end
 		
 		-- Now apply the blur along with the shadow shapes over the light canvas
-		love.graphics.setBlendMode("multiply", "alphamultiply")
+		love.graphics.setBlendMode("multiply", "premultiplied")
 		love.graphics.draw(self.ShadowCanvas, 0, 0)
 		
 		-- Reset the blending mode

--- a/LightWorld.lua
+++ b/LightWorld.lua
@@ -123,7 +123,7 @@ end
 
 function LightWorld:Draw()
 	
-	love.graphics.setBlendMode("multiply", "alphamultiply")
+	love.graphics.setBlendMode("multiply", "premultiplied")
 	love.graphics.setColor(255, 255, 255, 255)
 	love.graphics.draw(self.Canvas, 0, 0)
 	love.graphics.setBlendMode("alpha", "alphamultiply")

--- a/Star.lua
+++ b/Star.lua
@@ -129,7 +129,7 @@ function Star:Update()
 		end
 		
 		-- Draw the shadow shapes over the canvas
-		love.graphics.setBlendMode("multiply", "alphamultiply")
+		love.graphics.setBlendMode("multiply", "premultiplied")
 		love.graphics.draw(self.ShadowCanvas, 0, 0)
 		
 		-- Reset the blending mode


### PR DESCRIPTION
This commit changes
```lua
love.graphics.setBlendMode("alpha", "alphamultiply")
```
to
```lua
love.graphics.setBlendMode("alpha", "premultiplied")
```
as love 0.11 produces the error:
''Error: shadows/LightWorld.lua:126: The 'multiply' blend mode must be used with premultiplied alpha.
stack traceback:
	[string "boot.lua"]:637: in function <[string "boot.lua"]:633>
	[C]: in function 'setBlendMode'"


Love 0.11 also deprecated 
```lua
Body:getFixtureList()
```
in favor of
```lua
Body:getFixtures()
```